### PR TITLE
pkg/authorization: add delegateauthorizer and unit tests

### DIFF
--- a/pkg/authorization/bootstrap_policy_authorizer.go
+++ b/pkg/authorization/bootstrap_policy_authorizer.go
@@ -29,11 +29,11 @@ import (
 )
 
 type BootstrapPolicyAuthorizer struct {
-	delegate *rbac.RBACAuthorizer
+	bootstrapPolicy *rbac.RBACAuthorizer
 }
 
 func NewBootstrapPolicyAuthorizer(informers kcpkubernetesinformers.SharedInformerFactory) (authorizer.Authorizer, authorizer.RuleResolver) {
-	a := &BootstrapPolicyAuthorizer{delegate: rbac.New(
+	a := &BootstrapPolicyAuthorizer{bootstrapPolicy: rbac.New(
 		&rbac.RoleGetter{Lister: informers.Rbac().V1().Roles().Lister().Cluster(genericcontrolplane.LocalAdminCluster)},
 		&rbac.RoleBindingLister{Lister: informers.Rbac().V1().RoleBindings().Lister().Cluster(genericcontrolplane.LocalAdminCluster)},
 		&rbac.ClusterRoleGetter{Lister: informers.Rbac().V1().ClusterRoles().Lister().Cluster(genericcontrolplane.LocalAdminCluster)},
@@ -44,13 +44,13 @@ func NewBootstrapPolicyAuthorizer(informers kcpkubernetesinformers.SharedInforme
 }
 
 func (a *BootstrapPolicyAuthorizer) Authorize(ctx context.Context, attr authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
-	dec, reason, err := a.delegate.Authorize(ctx, attr)
+	dec, reason, err := a.bootstrapPolicy.Authorize(ctx, attr)
 	if err != nil {
 		err = fmt.Errorf("error authorizing bootstrap policy: %w", err)
 	}
-	return dec, fmt.Sprintf("bootstrap policy reason: %v", reason), err
+	return dec, fmt.Sprintf("bootstrap policy: %v", reason), err
 }
 
 func (a *BootstrapPolicyAuthorizer) RulesFor(ctx context.Context, user user.Info, namespace string) ([]authorizer.ResourceRuleInfo, []authorizer.NonResourceRuleInfo, bool, error) {
-	return a.delegate.RulesFor(ctx, user, namespace)
+	return a.bootstrapPolicy.RulesFor(ctx, user, namespace)
 }

--- a/pkg/authorization/decorator.go
+++ b/pkg/authorization/decorator.go
@@ -42,16 +42,19 @@ type Decorator struct {
 	key    string
 }
 
-func NewDecorator(target authorizer.Authorizer, key string) *Decorator {
+// NewDecorator returns a new authorizer which is associated with the given key.
+// The prefix key must not contain a trailing slash `/`.
+// Decorating functions are applied in the order they have been invoked.
+func NewDecorator(key string, target authorizer.Authorizer) *Decorator {
 	if strings.HasSuffix(key, "/") {
 		panic(fmt.Sprintf("audit prefix must not have a trailing slash: %q", key))
 	}
 	return &Decorator{target: target, key: key}
 }
 
-// AddAuditLogging logs every decision of the delegate authorizer
-// for the given audit prefix key.
-// Note: the prefix key must not contain a trailing slash `/`.
+// AddAuditLogging logs every decision of the target authorizer for the given audit prefix key
+// if the decision is not allowed.
+// All authorizer decisions are being logged in the audit log.
 func (d *Decorator) AddAuditLogging() *Decorator {
 	target := d.target
 	d.target = authorizer.AuthorizerFunc(func(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
@@ -59,7 +62,7 @@ func (d *Decorator) AddAuditLogging() *Decorator {
 
 		auditReasonMsg := reason
 		if err != nil {
-			auditReasonMsg = fmt.Sprintf("reason: %q, error: %v", reason, err)
+			auditReasonMsg = fmt.Sprintf("reason: %v, error: %v", reason, err)
 		}
 
 		kaudit.AddAuditAnnotations(
@@ -81,7 +84,8 @@ func (d *Decorator) AddAuditLogging() *Decorator {
 }
 
 // AddAnonymization anonymizes authorization decisions,
-// returning "access granted" in case of an allow decision and "access denied" otherwise.
+// returning "access granted" reason in case of an allow decision and "access denied" reason otherwise to the next decoration.
+// Previous decorations are not anonymized.
 func (d *Decorator) AddAnonymization() *Decorator {
 	target := d.target
 	d.target = authorizer.AuthorizerFunc(func(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
@@ -101,11 +105,14 @@ func (d *Decorator) AddAnonymization() *Decorator {
 	return d
 }
 
+// AddReasonAnnotation adds the authorizer key as a prefix to the authorizer reason and passes that to the next decoration.
+// This is useful where AddAnonymization was used as a decoration, but we still want to identify the authorizer in audit logs
+// when this decorator is passed as a delegate in an authorizer chains.
 func (d *Decorator) AddReasonAnnotation() *Decorator {
 	target := d.target
 	d.target = authorizer.AuthorizerFunc(func(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
 		dec, reason, err := target.Authorize(ctx, attr)
-		return dec, "delegated " + d.key + " authorizer reason: " + reason, err
+		return dec, d.key + ": " + reason, err
 	})
 	return d
 }
@@ -125,4 +132,13 @@ func decisionString(dec authorizer.Decision) string {
 		return DecisionDenied
 	}
 	return ""
+}
+
+// DelegateAuthorization delegates authorization to the given delegate authorizer
+// and prefixes the given reason with the reason after the given delegate authorizer executed.
+func DelegateAuthorization(delegationReason string, delegate authorizer.Authorizer) authorizer.Authorizer {
+	return authorizer.AuthorizerFunc(func(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+		dec, delegateReason, err := delegate.Authorize(ctx, attr)
+		return dec, "delegating due to " + delegationReason + ": " + delegateReason, err
+	})
 }

--- a/pkg/authorization/decorator_test.go
+++ b/pkg/authorization/decorator_test.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authorization
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	auditapis "k8s.io/apiserver/pkg/apis/audit"
+	"k8s.io/apiserver/pkg/audit"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+func TestDecorator(t *testing.T) {
+	alwaysAllow := authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+		return authorizer.DecisionAllow, "unanonymized allow", nil
+	})
+	alwaysDeny := authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+		return authorizer.DecisionDeny, "unanonymized denial", nil
+	})
+	alwaysNoOpinion := authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+		return authorizer.DecisionNoOpinion, "unanonymized no-opinion", nil
+	})
+	alwaysError := authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+		return authorizer.DecisionNoOpinion, "unanonymized failure", errors.New("unanonymized error")
+	})
+
+	for name, tc := range map[string]struct {
+		authz        authorizer.Authorizer
+		wantDecision authorizer.Decision
+		wantAudit    map[string]string
+		wantReason   string
+	}{
+		"topAllows": {
+			authz: NewDecorator("top", alwaysAllow).AddAuditLogging().AddAnonymization().AddReasonAnnotation(),
+
+			wantDecision: authorizer.DecisionAllow,
+			wantReason:   "top: access granted",
+
+			wantAudit: map[string]string{
+				"top/decision": "Allowed",
+				"top/reason":   "unanonymized allow",
+			},
+		},
+		"topAllowsWithoutReasonAnnotation": {
+			authz: NewDecorator("top", alwaysAllow).AddAuditLogging().AddAnonymization(),
+
+			wantDecision: authorizer.DecisionAllow,
+			wantReason:   "access granted",
+
+			wantAudit: map[string]string{
+				"top/decision": "Allowed",
+				"top/reason":   "unanonymized allow",
+			},
+		},
+		"topAllowsWithoutReasonAnnotationWithoutAnonymization": {
+			authz: NewDecorator("top", alwaysAllow).AddAuditLogging(),
+
+			wantDecision: authorizer.DecisionAllow,
+			wantReason:   "unanonymized allow",
+
+			wantAudit: map[string]string{
+				"top/decision": "Allowed",
+				"top/reason":   "unanonymized allow",
+			},
+		},
+		"topAllowsWithoutReasonAnnotationWithoutAnonymizationWithoutAuditLogging": {
+			authz: NewDecorator("top", alwaysAllow),
+
+			wantDecision: authorizer.DecisionAllow,
+			wantReason:   "unanonymized allow",
+
+			wantAudit: nil,
+		},
+		"topDelegatesToAllow": {
+			authz: NewDecorator("top",
+				DelegateAuthorization("top-to-bottom",
+					NewDecorator("bottom", alwaysAllow).AddAuditLogging().AddAnonymization().AddReasonAnnotation()),
+			).AddAuditLogging().AddAnonymization(),
+
+			wantDecision: authorizer.DecisionAllow,
+			wantReason:   "access granted",
+
+			wantAudit: map[string]string{
+				"bottom/decision": "Allowed",
+				"bottom/reason":   "unanonymized allow",
+
+				"top/decision": "Allowed",
+				"top/reason":   "delegating due to top-to-bottom: bottom: access granted",
+			},
+		},
+		"topDelegatesToDeny": {
+			authz: NewDecorator("top",
+				DelegateAuthorization("top-to-bottom",
+					NewDecorator("bottom", alwaysDeny).AddAuditLogging().AddAnonymization().AddReasonAnnotation()),
+			).AddAuditLogging().AddAnonymization(),
+
+			wantDecision: authorizer.DecisionDeny,
+			wantReason:   "access denied",
+
+			wantAudit: map[string]string{
+				"bottom/decision": "Denied",
+				"bottom/reason":   "unanonymized denial",
+
+				"top/decision": "Denied",
+				"top/reason":   "delegating due to top-to-bottom: bottom: access denied",
+			},
+		},
+		"topDelegatesToDelegateDelegatesToDeny": {
+			authz: NewDecorator("top",
+				DelegateAuthorization("top-to-middle", NewDecorator("middle",
+					DelegateAuthorization("middle-to-bottom", NewDecorator("bottom", alwaysDeny).AddAuditLogging().AddAnonymization().AddReasonAnnotation()),
+				).AddAuditLogging().AddAnonymization().AddReasonAnnotation()),
+			).AddAuditLogging().AddAnonymization(),
+
+			wantDecision: authorizer.DecisionDeny,
+			wantReason:   "access denied",
+
+			wantAudit: map[string]string{
+				"bottom/decision": "Denied",
+				"bottom/reason":   "unanonymized denial",
+
+				"middle/decision": "Denied",
+				"middle/reason":   "delegating due to middle-to-bottom: bottom: access denied",
+
+				"top/decision": "Denied",
+				"top/reason":   "delegating due to top-to-middle: middle: access denied",
+			},
+		},
+		"topDelegatesToDelegateDelegatesToAllow": {
+			authz: NewDecorator("top",
+				DelegateAuthorization("top-to-middle", NewDecorator("middle",
+					DelegateAuthorization("middle-to-bottom", NewDecorator("bottom", alwaysAllow).AddAuditLogging().AddAnonymization().AddReasonAnnotation()),
+				).AddAuditLogging().AddAnonymization().AddReasonAnnotation()),
+			).AddAuditLogging().AddAnonymization(),
+
+			wantDecision: authorizer.DecisionAllow,
+			wantReason:   "access granted",
+
+			wantAudit: map[string]string{
+				"bottom/decision": "Allowed",
+				"bottom/reason":   "unanonymized allow",
+
+				"middle/decision": "Allowed",
+				"middle/reason":   "delegating due to middle-to-bottom: bottom: access granted",
+
+				"top/decision": "Allowed",
+				"top/reason":   "delegating due to top-to-middle: middle: access granted",
+			},
+		},
+		"topDelegatesToDelegateDelegatesToNoOpinion": {
+			authz: NewDecorator("top",
+				DelegateAuthorization("top-to-middle", NewDecorator("middle",
+					DelegateAuthorization("middle-to-bottom", NewDecorator("bottom", alwaysNoOpinion).AddAuditLogging().AddAnonymization().AddReasonAnnotation()),
+				).AddAuditLogging().AddAnonymization().AddReasonAnnotation()),
+			).AddAuditLogging().AddAnonymization(),
+
+			wantDecision: authorizer.DecisionNoOpinion,
+			wantReason:   "access denied",
+
+			wantAudit: map[string]string{
+				"bottom/decision": "NoOpinion",
+				"bottom/reason":   "unanonymized no-opinion",
+
+				"middle/decision": "NoOpinion",
+				"middle/reason":   "delegating due to middle-to-bottom: bottom: access denied",
+
+				"top/decision": "NoOpinion",
+				"top/reason":   "delegating due to top-to-middle: middle: access denied",
+			},
+		},
+		"topDelegatesToDelegateDelegatesToError": {
+			authz: NewDecorator("top",
+				DelegateAuthorization("top-to-middle", NewDecorator("middle",
+					DelegateAuthorization("middle-to-bottom", NewDecorator("bottom", alwaysError).AddAuditLogging().AddAnonymization().AddReasonAnnotation()),
+				).AddAuditLogging().AddAnonymization().AddReasonAnnotation()),
+			).AddAuditLogging().AddAnonymization(),
+
+			wantDecision: authorizer.DecisionNoOpinion,
+			wantReason:   "access denied",
+
+			wantAudit: map[string]string{
+				"bottom/decision": "NoOpinion",
+				"bottom/reason":   "reason: unanonymized failure, error: unanonymized error",
+
+				"middle/decision": "NoOpinion",
+				"middle/reason":   "reason: delegating due to middle-to-bottom: bottom: access denied, error: unanonymized error",
+
+				"top/decision": "NoOpinion",
+				"top/reason":   "reason: delegating due to top-to-middle: middle: access denied, error: unanonymized error",
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx := audit.WithAuditContext(context.Background(), newAuditContext(auditapis.LevelMetadata))
+			attr := authorizer.AttributesRecord{}
+			dec, reason, _ := tc.authz.Authorize(ctx, attr)
+			if dec != tc.wantDecision {
+				t.Errorf("want decision %v got %v", tc.wantDecision, dec)
+			}
+			ev := audit.AuditEventFrom(ctx)
+			if diff := cmp.Diff(tc.wantAudit, ev.Annotations); diff != "" {
+				t.Errorf("audit log annotations differ: %v", diff)
+			}
+			if tc.wantReason != reason {
+				t.Errorf("want reason %q, got %q", tc.wantReason, reason)
+			}
+		})
+	}
+}
+
+func newAuditContext(l auditapis.Level) *audit.AuditContext {
+	return &audit.AuditContext{
+		Event: &auditapis.Event{
+			Level: l,
+		},
+	}
+}

--- a/pkg/authorization/local_authorizer.go
+++ b/pkg/authorization/local_authorizer.go
@@ -78,5 +78,5 @@ func (a *LocalAuthorizer) Authorize(ctx context.Context, attr authorizer.Attribu
 	if err != nil {
 		err = fmt.Errorf("error authorizing local policy for cluster %q: %w", cluster.Name, err)
 	}
-	return dec, fmt.Sprintf("local policy for cluster %q reason: %v", cluster.Name, reason), err
+	return dec, fmt.Sprintf("local cluster %q policy: %v", cluster.Name, reason), err
 }

--- a/pkg/authorization/requiredgroups_authorizer_test.go
+++ b/pkg/authorization/requiredgroups_authorizer_test.go
@@ -1,0 +1,239 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authorization
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	"github.com/kcp-dev/kcp/pkg/apis/core/v1alpha1"
+)
+
+func TestRequiredGroupsAuthorizer(t *testing.T) {
+
+	for name, tt := range map[string]struct {
+		requestedWorkspace    string
+		requestingUser        *user.DefaultInfo
+		wantReason, wantError string
+		wantDecision          authorizer.Decision
+		deepSARHeader         bool
+		logicalCluster        *v1alpha1.LogicalCluster
+	}{
+		"deep SAR": {
+			requestedWorkspace: "root:ready",
+			requestingUser:     newUser("user-unknown"),
+			deepSARHeader:      true,
+			wantDecision:       authorizer.DecisionAllow,
+			wantReason:         "delegating due to deep SAR request: allowed",
+		},
+		"missing cluster in request": {
+			requestingUser: newUser("user-unknown"),
+			wantDecision:   authorizer.DecisionNoOpinion,
+			wantReason:     "empty cluster name",
+		},
+		"system:kcp:logical-cluster-admin can always pass": {
+			requestedWorkspace: "root:ready",
+			requestingUser:     newUser("lcluster-admin", "system:kcp:logical-cluster-admin"),
+			wantDecision:       authorizer.DecisionAllow,
+			wantReason:         "delegating due to logical cluster admin access: allowed",
+		},
+		"service account from other cluster is granted access": {
+			requestedWorkspace: "root:ready",
+			requestingUser:     newServiceAccountWithCluster("sa", "anotherws"),
+			wantDecision:       authorizer.DecisionAllow,
+			wantReason:         "delegating due to service account access to logical cluster: allowed",
+		},
+		"service account from same cluster is granted access": {
+			requestedWorkspace: "root:ready",
+			requestingUser:     newServiceAccountWithCluster("sa", "root:ready"),
+			wantDecision:       authorizer.DecisionAllow,
+			wantReason:         "delegating due to service account access to logical cluster: allowed",
+		},
+		"permitted user is granted access to logical cluster without required groups": {
+			requestedWorkspace: "root:ready",
+			requestingUser:     newUser("user-access", "system:authenticated"),
+			wantDecision:       authorizer.DecisionAllow,
+			logicalCluster:     &v1alpha1.LogicalCluster{},
+			wantReason:         "delegating due to logical cluster does not require groups: allowed",
+		},
+		"permitted user is denied access to logical cluster with required groups": {
+			requestedWorkspace: "root:ready",
+			requestingUser:     newUser("user-access", "system:authenticated"),
+			wantDecision:       authorizer.DecisionDeny,
+			logicalCluster: &v1alpha1.LogicalCluster{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						"authorization.kcp.dev/required-groups": "special-group",
+					},
+				},
+			},
+			wantReason: "user is not a member of required groups: special-group",
+		},
+		"permitted user is allowed access to logical cluster with matching all of multiple disjunctive groups": {
+			requestedWorkspace: "root:ready",
+			requestingUser:     newUser("user-access", "special-group-1", "special-group-2"),
+			wantDecision:       authorizer.DecisionAllow,
+			logicalCluster: &v1alpha1.LogicalCluster{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						"authorization.kcp.dev/required-groups": "special-group-1;special-group-2",
+					},
+				},
+			},
+			wantReason: "delegating due to user is member of required groups: special-group-1;special-group-2: allowed",
+		},
+		"permitted user is allowed access to logical cluster with matching one of multiple disjunctive groups": {
+			requestedWorkspace: "root:ready",
+			requestingUser:     newUser("user-access", "special-group-1", "other-group"),
+			wantDecision:       authorizer.DecisionAllow,
+			logicalCluster: &v1alpha1.LogicalCluster{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						"authorization.kcp.dev/required-groups": "special-group-1;special-group-2",
+					},
+				},
+			},
+			wantReason: "delegating due to user is member of required groups: special-group-1;special-group-2: allowed",
+		},
+		"permitted user is allowed access to logical cluster with multiple conjunctive groups": {
+			requestedWorkspace: "root:ready",
+			requestingUser:     newUser("user-access", "special-group-1", "special-group-2"),
+			wantDecision:       authorizer.DecisionAllow,
+			logicalCluster: &v1alpha1.LogicalCluster{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						"authorization.kcp.dev/required-groups": "special-group-1,special-group-2",
+					},
+				},
+			},
+			wantReason: "delegating due to user is member of required groups: special-group-1,special-group-2: allowed",
+		},
+		"permitted user is denied access to logical cluster with multiple conjunctive groups": {
+			requestedWorkspace: "root:ready",
+			requestingUser:     newUser("user-access", "special-group-1", "other-group"),
+			wantDecision:       authorizer.DecisionDeny,
+			logicalCluster: &v1alpha1.LogicalCluster{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						"authorization.kcp.dev/required-groups": "special-group-1,special-group-2",
+					},
+				},
+			},
+			wantReason: "user is not a member of required groups: special-group-1,special-group-2",
+		},
+		"permitted user is allowed access to logical cluster with matching two of multiple conjunctive and disjunctive groups": {
+			requestedWorkspace: "root:ready",
+			requestingUser:     newUser("user-access", "special-group-1", "special-group-2"),
+			wantDecision:       authorizer.DecisionAllow,
+			logicalCluster: &v1alpha1.LogicalCluster{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						"authorization.kcp.dev/required-groups": "special-group-1,special-group-2;special-group-3",
+					},
+				},
+			},
+			wantReason: "delegating due to user is member of required groups: special-group-1,special-group-2;special-group-3: allowed",
+		},
+		"permitted user is allowed access to logical cluster with matching one of multiple conjunctive and disjunctive groups": {
+			requestedWorkspace: "root:ready",
+			requestingUser:     newUser("user-access", "special-group-3"),
+			wantDecision:       authorizer.DecisionAllow,
+			logicalCluster: &v1alpha1.LogicalCluster{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						"authorization.kcp.dev/required-groups": "special-group-1,special-group-2;special-group-3",
+					},
+				},
+			},
+			wantReason: "delegating due to user is member of required groups: special-group-1,special-group-2;special-group-3: allowed",
+		},
+		"permitted user is denied access to logical cluster with matching only one of multiple conjunctive and disjunctive groups": {
+			requestedWorkspace: "root:ready",
+			requestingUser:     newUser("user-access", "special-group-1"),
+			wantDecision:       authorizer.DecisionDeny,
+			logicalCluster: &v1alpha1.LogicalCluster{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						"authorization.kcp.dev/required-groups": "special-group-1,special-group-2;special-group-3",
+					},
+				},
+			},
+			wantReason: "user is not a member of required groups: special-group-1,special-group-2;special-group-3",
+		},
+		"permitted user is denied access to logical cluster with matching none of multiple conjunctive and disjunctive groups": {
+			requestedWorkspace: "root:ready",
+			requestingUser:     newUser("user-access", "system:authenticated"),
+			wantDecision:       authorizer.DecisionDeny,
+			logicalCluster: &v1alpha1.LogicalCluster{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						"authorization.kcp.dev/required-groups": "special-group-1,special-group-2;special-group-3",
+					},
+				},
+			},
+			wantReason: "user is not a member of required groups: special-group-1,special-group-2;special-group-3",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			if tt.requestedWorkspace != "" {
+				ctx = request.WithCluster(ctx, request.Cluster{
+					Name: logicalcluster.Name(tt.requestedWorkspace),
+				})
+			}
+			if tt.deepSARHeader {
+				ctx = context.WithValue(ctx, deepSARKey, true)
+			}
+
+			recordingAuthorizer := &recordingAuthorizer{decision: authorizer.DecisionAllow, reason: "allowed"}
+			attr := authorizer.AttributesRecord{
+				User: tt.requestingUser,
+			}
+			authz := requiredGroupsAuthorizer{
+				getLogicalCluster: func(logicalCluster logicalcluster.Name) (*v1alpha1.LogicalCluster, error) {
+					return tt.logicalCluster, nil
+				},
+				delegate: recordingAuthorizer,
+			}
+
+			gotDecision, gotReason, err := authz.Authorize(ctx, attr)
+			gotErr := ""
+			if err != nil {
+				gotErr = err.Error()
+			}
+
+			if gotErr != tt.wantError {
+				t.Errorf("want error %q, got %q", tt.wantError, gotErr)
+			}
+
+			if gotReason != tt.wantReason {
+				t.Errorf("want reason %q, got %q", tt.wantReason, gotReason)
+			}
+
+			if gotDecision != tt.wantDecision {
+				t.Errorf("want decision %v, got %v", tt.wantDecision, gotDecision)
+			}
+		})
+	}
+}

--- a/pkg/authorization/system_crd_authorizer.go
+++ b/pkg/authorization/system_crd_authorizer.go
@@ -50,5 +50,5 @@ func (a *SystemCRDAuthorizer) Authorize(ctx context.Context, attr authorizer.Att
 		}
 	}
 
-	return a.delegate.Authorize(ctx, attr)
+	return DelegateAuthorization("no system CRD violation", a.delegate).Authorize(ctx, attr)
 }

--- a/pkg/server/options/authorization.go
+++ b/pkg/server/options/authorization.go
@@ -102,24 +102,24 @@ func (s *Authorization) ApplyTo(config *genericapiserver.Config, informer kcpkub
 
 	// kcp authorizers
 	bootstrapAuth, bootstrapRules := authz.NewBootstrapPolicyAuthorizer(informer)
-	bootstrapAuth = authz.NewDecorator(bootstrapAuth, "bootstrap.authorization.kcp.dev").AddAuditLogging().AddAnonymization().AddReasonAnnotation()
+	bootstrapAuth = authz.NewDecorator("bootstrap.authorization.kcp.dev", bootstrapAuth).AddAuditLogging().AddAnonymization().AddReasonAnnotation()
 
 	localAuth, localResolver := authz.NewLocalAuthorizer(informer)
-	localAuth = authz.NewDecorator(localAuth, "local.authorization.kcp.dev").AddAuditLogging().AddAnonymization().AddReasonAnnotation()
+	localAuth = authz.NewDecorator("local.authorization.kcp.dev", localAuth).AddAuditLogging().AddAnonymization().AddReasonAnnotation()
 
 	maxPermissionPolicyAuth := authz.NewMaximalPermissionPolicyAuthorizer(informer, kcpinformer, union.New(bootstrapAuth, localAuth))
-	maxPermissionPolicyAuth = authz.NewDecorator(maxPermissionPolicyAuth, "maxpermissionpolicy.authorization.kcp.dev").AddAuditLogging().AddAnonymization().AddReasonAnnotation()
+	maxPermissionPolicyAuth = authz.NewDecorator("maxpermissionpolicy.authorization.kcp.dev", maxPermissionPolicyAuth).AddAuditLogging().AddAnonymization().AddReasonAnnotation()
 
 	systemCRDAuth := authz.NewSystemCRDAuthorizer(maxPermissionPolicyAuth)
-	systemCRDAuth = authz.NewDecorator(systemCRDAuth, "systemcrd.authorization.kcp.dev").AddAuditLogging().AddAnonymization().AddReasonAnnotation()
+	systemCRDAuth = authz.NewDecorator("systemcrd.authorization.kcp.dev", systemCRDAuth).AddAuditLogging().AddAnonymization().AddReasonAnnotation()
 
 	contentAuth := authz.NewWorkspaceContentAuthorizer(informer, workspaceLister, systemCRDAuth)
-	contentAuth = authz.NewDecorator(contentAuth, "content.authorization.kcp.dev").AddAuditLogging().AddAnonymization().AddReasonAnnotation()
+	contentAuth = authz.NewDecorator("content.authorization.kcp.dev", contentAuth).AddAuditLogging().AddAnonymization().AddReasonAnnotation()
 
-	topLevelAuth := authz.NewRequiredGroupsAuthorizer(workspaceLister, contentAuth)
-	topLevelAuth = authz.NewDecorator(topLevelAuth, "requiredgroups.authorization.kcp.dev").AddAuditLogging().AddAnonymization()
+	requiredGroupsAuth := authz.NewRequiredGroupsAuthorizer(workspaceLister, contentAuth)
+	requiredGroupsAuth = authz.NewDecorator("requiredgroups.authorization.kcp.dev", requiredGroupsAuth).AddAuditLogging().AddAnonymization()
 
-	authorizers = append(authorizers, topLevelAuth)
+	authorizers = append(authorizers, requiredGroupsAuth)
 
 	config.RuleResolver = union.NewRuleResolvers(bootstrapRules, localResolver)
 	config.Authorization.Authorizer = union.New(authorizers...)

--- a/pkg/virtual/apiexport/builder/build.go
+++ b/pkg/virtual/apiexport/builder/build.go
@@ -225,10 +225,10 @@ func digestUrl(urlPath, rootPathPrefix string) (
 
 func newAuthorizer(kubeClusterClient, deepSARClient kcpkubernetesclientset.ClusterInterface, kcpinformers kcpinformers.SharedInformerFactory) authorizer.Authorizer {
 	maximalPermissionAuth := virtualapiexportauth.NewMaximalPermissionAuthorizer(deepSARClient, kcpinformers.Apis().V1alpha1().APIExports())
-	maximalPermissionAuth = authorization.NewDecorator(maximalPermissionAuth, "virtual.apiexport.maxpermissionpolicy.authorization.kcp.dev").AddAuditLogging().AddAnonymization().AddReasonAnnotation()
+	maximalPermissionAuth = authorization.NewDecorator("virtual.apiexport.maxpermissionpolicy.authorization.kcp.dev", maximalPermissionAuth).AddAuditLogging().AddAnonymization().AddReasonAnnotation()
 
 	apiExportsContentAuth := virtualapiexportauth.NewAPIExportsContentAuthorizer(maximalPermissionAuth, kubeClusterClient)
-	apiExportsContentAuth = authorization.NewDecorator(apiExportsContentAuth, "virtual.apiexport.content.authorization.kcp.dev").AddAuditLogging().AddAnonymization()
+	apiExportsContentAuth = authorization.NewDecorator("virtual.apiexport.content.authorization.kcp.dev", apiExportsContentAuth).AddAuditLogging().AddAnonymization()
 
 	return apiExportsContentAuth
 }


### PR DESCRIPTION
example audit entries:
```
  "annotations": {
    "authorization.k8s.io/decision": "allow",
    "authorization.k8s.io/reason": "access granted",
    "bootstrap.authorization.kcp.dev/decision": "Allowed",
    "bootstrap.authorization.kcp.dev/reason": "bootstrap policy: RBAC: allowed by ClusterRoleBinding \"system:kcp:tenancy:workspace-bootstrapper\" of ClusterRole \"system:kcp:tenancy:workspace-bootstrapper\" to Group \"system:kcp:tenancy:workspa
ce-bootstrapper\"",
    "content.authorization.kcp.dev/decision": "Allowed",
    "content.authorization.kcp.dev/reason": "delegating due to user access to thisworkspace: systemcrd.authorization.kcp.dev: access granted",
    "maxpermissionpolicy.authorization.kcp.dev/decision": "Allowed",
    "maxpermissionpolicy.authorization.kcp.dev/reason": "delegating due to unbound resource: bootstrap.authorization.kcp.dev: access granted",
    "requiredgroups.authorization.kcp.dev/decision": "Allowed",
    "requiredgroups.authorization.kcp.dev/reason": "delegating due to user is member of required groups: empty-group: content.authorization.kcp.dev: access granted",
    "systemcrd.authorization.kcp.dev/decision": "Allowed",
    "systemcrd.authorization.kcp.dev/reason": "delegating due to no system CRD violation: maxpermissionpolicy.authorization.kcp.dev: access granted",
    "tenancy.kcp.dev/workspace": "root-e2e--org--dtrbv"
  }
```