### PR TITLE
🐛 syncer: use logicalcluster from synctarget

### DIFF
--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -176,7 +176,7 @@ func StartSyncer(ctx context.Context, cfg *SyncerConfig, numSyncerThreads int, i
 		return err
 	}
 
-	syncTargetKey := workloadv1alpha1.ToSyncTargetKey(cfg.SyncTargetClusterName, cfg.SyncTargetName)
+	syncTargetKey := workloadv1alpha1.ToSyncTargetKey(logicalcluster.From(syncTarget), cfg.SyncTargetName)
 	logger = logger.WithValues(SyncTargetKey, syncTargetKey)
 	ctx = klog.NewContext(ctx, logger)
 


### PR DESCRIPTION
## Summary

Use logicalcluster from synctarget object instead of using the workspace path passed via args to compute the synctargetkey.

